### PR TITLE
Add dashboard index tests

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,6 +9,12 @@ class TestIATIDashboard(WebTestBase):
         'Dashboard Homepage': {
             'url': 'http://dashboard.iatistandard.org/'
         }
+        , 'Dashboard Publisher Index Page': {
+            'url': 'http://dashboard.iatistandard.org/publisher/'
+        }
+        , 'Dashboard Activity Index Page': {
+            'url': 'http://dashboard.iatistandard.org/activities/'
+        }
     }
 
     def test_contains_links(self, loaded_request):


### PR DESCRIPTION
This adds tests for dashboard index pages that do not display generated content.

* [#12] should be merged first.
* [IATI/IATI-Dashboard#411] should be resolved and the update made live before merging this.