### PR TITLE
Test failure debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pyenv/
 *.pyc
+travis_test_branch.sh

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -7,8 +7,16 @@ class TestIATIDatastore(WebTestBase):
         'Datastore Homepage': {
             'url': 'http://datastore.iatistandard.org/'
         }
-        , 'API - Activities Updated Since Yesterday': {
+        , 'API - Activities Updated since Yesterday': {
             'url': 'http://datastore.iatistandard.org/api/1/access/activity.xml?limit=0&last-updated-datetime__gt=' + str(date.today() - timedelta(days=1))
+            , 'min_response_size': 295
+        }
+        , 'API - Activities Updated since 2 days ago': {
+            'url': 'http://datastore.iatistandard.org/api/1/access/activity.xml?limit=0&last-updated-datetime__gt=' + str(date.today() - timedelta(days=2))
+            , 'min_response_size': 295
+        }
+        , 'API - Activities Updated since 3 days ago': {
+            'url': 'http://datastore.iatistandard.org/api/1/access/activity.xml?limit=0&last-updated-datetime__gt=' + str(date.today() - timedelta(days=3))
             , 'min_response_size': 295
         }
         , 'Datastore download: csv': {
@@ -33,7 +41,7 @@ class TestIATIDatastore(WebTestBase):
 
         assert "http://iatiregistry.org/" in result
 
-    @pytest.mark.parametrize("target_request", ["API - Activities Updated Since Yesterday"])
+    @pytest.mark.parametrize("target_request", ["API - Activities Updated since Yesterday", "API - Activities Updated since 2 days ago", "API - Activities Updated since 3 days ago"])
     def test_recent_activities(self, target_request):
         """
         Test that the datastore API knows of activities updated in the past


### PR DESCRIPTION
The datastore test_recent_activities() test is failing between midnight and 6am GMT on a daily basis.

This adds a pair of additional tests to check for activities further in the past. These will demonstrate whether the issue is simply related to activities taking more than a day to update, or whether there is something more major happening.