### PR TITLE
Remove invalid datastore test

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -7,10 +7,6 @@ class TestIATIDatastore(WebTestBase):
         'Datastore Homepage': {
             'url': 'http://datastore.iatistandard.org/'
         }
-        , 'API - Activities Updated since Yesterday-ish': {
-            'url': 'http://datastore.iatistandard.org/api/1/access/activity.xml?limit=0&last-updated-datetime__gt=' + str(date.today() - timedelta(days=(1 if datetime.utcnow().hour >= 8 else 2)))
-            , 'min_response_size': 295
-        }
         , 'API - Activities Updated since 2 days ago': {
             'url': 'http://datastore.iatistandard.org/api/1/access/activity.xml?limit=0&last-updated-datetime__gt=' + str(date.today() - timedelta(days=2))
             , 'min_response_size': 295


### PR DESCRIPTION
This removes a test against the datastore that requires data from yesterday-ish to exist. Due to when the datastore updates itself from the Registry, this test cannot always work. As such, this is being removed, and the tests that provide a larger time period are left.