### PR TITLE
Add basic d-portal tests

### DIFF
--- a/tests/test_d_portal.py
+++ b/tests/test_d_portal.py
@@ -1,0 +1,9 @@
+import pytest
+from web_test_base import *
+
+class TestDPortal(WebTestBase):
+    requests_to_load = {
+        'D-Portal Homepage': {
+            'url': 'http://d-portal.org/'
+        }
+    }

--- a/tests/test_d_portal.py
+++ b/tests/test_d_portal.py
@@ -5,5 +5,6 @@ class TestDPortal(WebTestBase):
     requests_to_load = {
         'D-Portal Homepage': {
             'url': 'http://d-portal.org/'
+            , 'min_response_size': 1100
         }
     }


### PR DESCRIPTION
This adds the basic tests (200 error and response length) for the d-portal website. It may be necessary to modify the base response length depending on what is actually returned in a non-JS format.