### PR TITLE
transparencyindicator -> summary_stats

### DIFF
--- a/tests/test_backup_server.py
+++ b/tests/test_backup_server.py
@@ -144,7 +144,7 @@ class TestIATIBackupServer:
         "comprehensiveness_financials.csv",
         "comprehensiveness_valueadded.csv",
         "coverage.csv",
-        "transparencyindicator.csv"])
+        "summary_stats.csv"])
     def test_publisher_stats_backup(self, filename_suffix):
         """
         Tests that a monthly backup has been made of staistics that form the Global


### PR DESCRIPTION
Fixes the filename check for the 'summary statistics' CSV file. The original filename
name change was made in IATI/IATI-Dashboard@79c5b86 and the change to the backup
process was made in IATI/operations-helpers@0c0941c