### PR TITLE
Whitelist test paths using pytest config file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
Adds a pytest.ini file to specify that tests should only be
run if they are contained within the 'tests' directory. This
prevents issues that often occur on macs when pytest looks
for tests within a virtual environment configuration.