### PR TITLE
Add exponential backup for failed requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Technology Overview
 
 Tests are written using `pytest <http://doc.pytest.org>`_.
 
-Most tests are designed to obtain HTML and associated content from IATI websites, using the `requests library <http://docs.python-requests.org>`_. Additional tests on the status of backups are made using the `paramiko module <http://www.paramiko.org>`_, which checks the status of expected backup files via an SSH connection.
+Most tests are designed to obtain HTML and associated content from IATI websites, using the `requests library <http://docs.python-requests.org>`_. This retries failed requests several times should a failure occur, so as to reduce flakiness. Additional tests on the status of backups are made using the `paramiko module <http://www.paramiko.org>`_, which checks the status of expected backup files via an SSH connection.
 
 These tests are run daily (at around 2pm) using Travis `cron jobs <https://docs.travis-ci.com/user/cron-jobs/>`_. They are also run every 15 minutes throughout the day by use of a Travis API call from an IATI-managed server.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff==1.2.1 # rq.filter: <2.0
 lxml==3.7.1 # rq.filter: <4.0
 paramiko==2.1.1 # rq.filter: <3.0
 pytest==3.0.5 # rq.filter: <4.0

--- a/tests/web_test_base.py
+++ b/tests/web_test_base.py
@@ -1,3 +1,4 @@
+import backoff
 import pytest
 import requests
 
@@ -62,6 +63,7 @@ class WebTestBase:
         return utility.substring_in_list(text_to_find, result)
 
     @classmethod
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
     def setup_class(cls):
         """
         Initialise the class


### PR DESCRIPTION
This means that if a request fails, another attempt will be made. This is to deal with somewhat flaky tests for Discuss.

It also hides intermittent problems. This is deemed acceptable - the number of retries could be reduced if desired.