### PR TITLE
Revert "Skip Dashboard test for time last generated"

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,7 +20,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 3 days.


### PR DESCRIPTION
This reverts commit 296ced269a80eb2745d63a93e51501197613eeb1.
The Dashboard has since fully regenerated.