### PR TITLE
Update test_aid_transparency.py

### DIFF
--- a/tests/test_aid_transparency.py
+++ b/tests/test_aid_transparency.py
@@ -68,7 +68,7 @@ class TestAidTransparency(WebTestBase):
         Test that the image for the latest news item loads correctly.
         """
         req = self.loaded_request_from_test_name(target_request)
-        min_img_file_size = 2048
+        min_img_file_size = 1024
 
         img_url = utility.locate_xpath_result(req, '//*[@id="home-featured"]/div/article[1]/div[1]/a/img/@src')
         assert len(img_url) == 1


### PR DESCRIPTION
Reduce min filesize for images on the aidtransparency homepage.

There is currently an image of the Guinea flag in the tested location.
This is 3 vertical stripes, and so does not have a big filesize.