### PR TITLE
Test number of publishers on query builder

### DIFF
--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -18,14 +18,21 @@ class TestQueryBuilder(WebTestBase):
                 'recipient-region[]': '298',
                 'submit': 'Submit'
             }
+        },
+        'Publisher Information': {
+            'url': 'http://datastore.iatistandard.org/query/helpers/groups_cache_dc.json',
+            'min_response_size': 1500000
         }
     }
 
-    def test_locate_links(self, loaded_request):
+    @pytest.mark.parametrize("target_request", ["IATI Query Builder", "POST Example"])
+    def test_locate_links(self, target_request):
         """
         Tests that a page contains links to the defined URLs.
         """
-        result = utility.get_links_from_page(loaded_request)
+        req = self.loaded_request_from_test_name(target_request)
+
+        result = utility.get_links_from_page(req)
 
         assert "http://datastore.iatistandard.org/" in result
 


### PR DESCRIPTION
This ensures both that the underlying JSON is a big file, and that the Query Builder is displaying a number of publishers that is roughly similar to the Registry