### PR TITLE
Test Dashboard page that is generated late in the process.

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,6 +9,9 @@ class TestIATIDashboard(WebTestBase):
     requests_to_load = {
         'Dashboard Homepage': {
             'url': 'http://dashboard.iatistandard.org/'
+        },
+        'Page Generated Late in Process': {
+            'url': 'http://dashboard.iatistandard.org/element/iati-activity_result_description_narrative.html'
         }
     }
 


### PR DESCRIPTION
Test a page that is generated late in the process.

The chosen page is the page that, during the last generation of the Dashboard, was the last page to generate that will consistently appear. One other page was generated later, though this refers to a custom namespace used by one organisation, so is not a good candidate to rely upon.