### PR TITLE
Skip Dashboard test for time last generated

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
+    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 4 days.


### PR DESCRIPTION
At present, the Dashboard has not fully regenerated since `2017-10-25 05:19:15 +0100`. The Dashboard did not generate correctly over recent days, probably due to concurrency issues. Today's Dashboard run appears to be running ok, though will still take some hours to complete.