### PR TITLE
Revert "Skip Dashboard test for time last generated"

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 4 days.


### PR DESCRIPTION
This reverts commit 0f868c9fd144ad842c495f0e64d0127b3b4ea925.
The Dashboard fully generated again around 17:00 on Saturday
28 October. It is not known why the Dashboard failed to
generate for those days.