### PR TITLE
Remove strict xfail from Dashboard recently generated test

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 4 days.


### PR DESCRIPTION
The Dashboard failed for an unknown reason over recent days, but is now generating again.