### PR TITLE
Increase time threshold for checking Dashboard regenerations

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -25,9 +25,9 @@ class TestIATIDashboard(WebTestBase):
 
     def test_recently_generated(self, loaded_request):
         """
-        Tests that the dashboard was generated in the past 4 days.
+        Tests that the dashboard was generated in the past 7 days.
         """
-        max_delay = timedelta(days=4)
+        max_delay = timedelta(days=7)
         generation_time_xpath = '//*[@id="footer"]/div/p/em[1]'
         data_time_xpath = '//*[@id="footer"]/div/p/em[2]'
 


### PR DESCRIPTION
Increases the number of days before tests fail when the Dashboard does not successfuly regenerate.