### PR TITLE
Revert "Add strict xfail to Dashboard recently generated tests"

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
This reverts commit 3c1d2bf6d17c924c7826b4a8cccf88b4eca9835f.
The Dashboard has successfully regenerated on 2018-01-20 so this test can be re-activated.