### PR TITLE
Update test_dashboard.py

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strist=True)
+    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
+    @pytest.mark.xfail(strist=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
The Dashboard has not generated recently due to changes to the frequency surrounding data collection for the 2018 Annual Report.

As such, marking as xfail while it transitions to normal generation frequency.