### PR TITLE
Increase the allowed difference for the number of publishers

### DIFF
--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -221,7 +221,7 @@ class TestGlobalConsistency(WebTestBase):
         Test to ensure the publisher count is consistent, within a margin of error,
         between the registry and dashboard.
         """
-        max_registry_disparity = 0.01
+        max_registry_disparity = 0.03
 
         assert registry_home_publisher_count >= dash_home_publisher_count * (1 - max_registry_disparity)
         assert registry_home_publisher_count <= dash_home_publisher_count * (1 + max_registry_disparity)


### PR DESCRIPTION
Increases the allowed difference between the number of publishers reported by the Registry and the Dashboard. This is necessary as the Dashboard now only updates once every three days: https://discuss.iatistandard.org/t/changes-to-the-updating-of-dashboard-publisher-statistics/1172

Therefore there is a higher chance that the number of publishers will be inconsistent as there will be more time for new publishers to be created on the Registry.