### PR TITLE
Mark activity consistency check as xfail

### DIFF
--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -135,6 +135,7 @@ class TestGlobalConsistency(WebTestBase):
         assert dash_home_activity_count >= dash_home_unique_activity_count
         assert dash_activities_activity_count >= dash_activities_unique_activity_count
 
+    @pytest.mark.xfail(strict=True)
     def test_activity_count_consistency(self, datastore_api_activity_count, dash_home_unique_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,


### PR DESCRIPTION
Marks the activity count check between the Datastore and Dashboard as an expected failure. This is because the number of activities on the Datastore has increased by an expected level, but the Dashboard has not fully generated for three days (as expected).

Marking as `xfail` for the time being (rather than increasing the allowed disparity) in order to see if this problem occurs regularly enough to warrant a change in the criteria of the test.