### PR TITLE
Revert "Mark activity consistency check as xfail"

### DIFF
--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -135,7 +135,6 @@ class TestGlobalConsistency(WebTestBase):
         assert dash_home_activity_count >= dash_home_unique_activity_count
         assert dash_activities_activity_count >= dash_activities_unique_activity_count
 
-    @pytest.mark.xfail(strict=True)
     def test_activity_count_consistency(self, datastore_api_activity_count, dash_home_unique_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,


### PR DESCRIPTION
Reverts IATI/IATI-Website-Tests#92

The Dashboard has now regenerated, so this `xfail` can be removed.