### PR TITLE
Revert xfail dashboard

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
Reverts IATI/IATI-Website-Tests#98 since the Dashboard completed generation on Mar 24 at 15:53. It is unknown why previous generations failed.

