### PR TITLE
Revert "commenting out non-working links so Registry tests will at least run …"

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,19 +3,18 @@ from web_test_base import *
 
 class TestIATIRegistry(WebTestBase):
     requests_to_load = {
-    # commenting out http and www links for now as they're preventing all other links from running
-        # 'IATI Registry Homepage - http, no www': {
-        #     'url': 'http://iatiregistry.org/'
-        # },
-        # 'IATI Registry Homepage - http, with www': {
-        #     'url': 'http://www.iatiregistry.org/'
-        # },
+        'IATI Registry Homepage - http, no www': {
+            'url': 'http://iatiregistry.org/'
+        },
+        'IATI Registry Homepage - http, with www': {
+            'url': 'http://www.iatiregistry.org/'
+        },
         'IATI Registry Homepage - https, no www': {
             'url': 'https://iatiregistry.org/'
         },
-        # 'IATI Registry Homepage - https, with www': {
-        #     'url': 'https://www.iatiregistry.org/'
-        # },
+        'IATI Registry Homepage - https, with www': {
+            'url': 'https://www.iatiregistry.org/'
+        },
         'IATI Registry Registration Page': {
             'url': 'https://iatiregistry.org/user/register'
         },


### PR DESCRIPTION
Reverts IATI/IATI-Website-Tests#100 as issues with the Registry SSL certificate and redirects have been resolved.

