### PR TITLE
Revert "Mark as xfail until issue can be investigated"

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -66,7 +66,6 @@ class TestIATIDatastore(WebTestBase):
 
         assert result.startswith(content_type)
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize("target_request", ["Datastore list of datasets"])
     def test_last_successful_fetch(self, target_request):
         """Test that the datastore has successfully fetched data within the expected time frame."""


### PR DESCRIPTION
Reverts IATI/IATI-Website-Tests#101 as the Dashboard successfully completed generating on Apr 9 at 18:59. There have been no further investigations as to why the issue arose in the first place.