### PR TITLE
Revert xfail on Dashboard

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
Reverts xfail to the Dashboard 'recently generated test' (made in cc507f8) as the Dashboard successfully completed generating on Apr 9 at 18:59. There have been no further investigations as to why the issue arose in the first place.