### PR TITLE
Remove xfail for test_last_successful_fetch

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -66,7 +66,6 @@ class TestIATIDatastore(WebTestBase):
 
         assert result.startswith(content_type)
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize("target_request", ["Datastore list of datasets"])
     def test_last_successful_fetch(self, target_request):
         """Test that the datastore has successfully fetched data within the expected time frame."""


### PR DESCRIPTION
A fix was made in IATI/IATI-Datastore#307 which results in latest activities being successfully processed again.