### PR TITLE
Revert "xfail dashboard generation tests until dashboard successfully generates"

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,7 +23,6 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
-    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
Reverts IATI/IATI-Website-Tests#106

The Dashboard has now generated:
> Generated on 2018-04-23 19:23:05 +0100 from data downloaded 2018-04-22 05:15:17 +0100.

Further investigations into why this tool failed have not been undertaken at this stage.