### PR TITLE
Mark Dashboard publisher count consistency as xfail

### DIFF
--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -216,6 +216,7 @@ class TestGlobalConsistency(WebTestBase):
         """
         assert dash_home_publisher_count == dash_publishers_publisher_count
 
+    @pytest.mark.xfail(strict=True)
     def test_publisher_count_consistency_dashboard(self, registry_home_publisher_count, dash_home_publisher_count):
         """
         Test to ensure the publisher count is consistent, within a margin of error,


### PR DESCRIPTION
The number of publishers on the Registry is increasing rapidly as Belgian NGOs are signing up in advance of a Belgian government publishing deadline. As such the frequency of the Dashboard generation process cannot keep up. Marking as xfail as the number of NGO registrations is expected to tail off as the Belgian government publishing deadline passes.