### PR TITLE
xfail Dashboard checks

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
+    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -189,6 +189,7 @@ class TestGlobalConsistency(WebTestBase):
         """
         assert dash_home_org_file_count == dash_files_org_file_count
 
+    @pytest.mark.xfail(strict=True)
     def test_organisation_dataset_count_consistency(self, registry_organisation_file_count, dash_home_org_file_count, dash_files_org_file_count):
         """
         Test to ensure the activity file count is consistent, within a margin of error,


### PR DESCRIPTION
xfails the Dashboard recently generated checks (given the Dashboard last generated on 2018-04-23 19:23:05.

Also xfails the Dashboard check for the number of org files, given an increased number of new publisher registrations (as described in #109).