### PR TITLE
Mark the Dashboard recently generated test as xfail

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
+    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
The Dashboard last generated on 2018-05-14, following a manual rebuild of the last stage of the build generation process. It has not completed on following attempts for an as yet unknown reason.