### PR TITLE
Mark the Dashboard recently generated test as xfail

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -23,6 +23,7 @@ class TestIATIDashboard(WebTestBase):
 
         assert "https://github.com/IATI/IATI-Dashboard/" in result
 
+    @pytest.mark.xfail(strict=True)
     def test_recently_generated(self, loaded_request):
         """
         Tests that the dashboard was generated in the past 7 days.


### PR DESCRIPTION
The Dashboard last generated from data on 2018-06-07. It has not generated since then for an as not unknown reason.