### PR TITLE
Add iatistandard homepage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 pyenv/
 *.pyc
 travis_test_branch.sh
+.pytest_cache
 
 #
 # Python .gitignore

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -12,6 +12,9 @@ class TestGlobalConsistency(WebTestBase):
         'IATI Registry - Organisation Dataset Page': {
             'url': 'https://iatiregistry.org/dataset?q=&filetype=Organisation'
         },
+        'IATI Standard - Homepage': {
+            'url': 'https://iatistandard.org/'
+        },
         'IATI Dashboard - Homepage': {
             'url': 'http://dashboard.iatistandard.org/'
         },
@@ -107,6 +110,14 @@ class TestGlobalConsistency(WebTestBase):
     def query_builder_publisher_count(cls):
         return cls._count_element_on_page('Query Builder', '//*[@id="reporting-org"]/option')
 
+    @pytest.fixture
+    def standard_home_activity_count(cls):
+        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="num_iati_activities"]')
+
+    @pytest.fixture
+    def standard_home_publisher_count(cls):
+        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="num_iati_organisations"]')
+
     def test_activity_count_above_min(self, dash_home_activity_count, dash_home_unique_activity_count, dash_activities_activity_count, dash_activities_unique_activity_count, datastore_api_activity_count):
         """
         Test to ensure the unique activity count is above a specified minumum value.
@@ -135,7 +146,7 @@ class TestGlobalConsistency(WebTestBase):
         assert dash_home_activity_count >= dash_home_unique_activity_count
         assert dash_activities_activity_count >= dash_activities_unique_activity_count
 
-    def test_activity_count_consistency(self, datastore_api_activity_count, dash_home_unique_activity_count):
+    def test_activity_count_consistency_datastore_dashboard(self, datastore_api_activity_count, dash_home_unique_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,
         between the datastore and dashboard.
@@ -144,6 +155,16 @@ class TestGlobalConsistency(WebTestBase):
 
         assert datastore_api_activity_count >= dash_home_unique_activity_count * (1 - max_datastore_disparity)
         assert datastore_api_activity_count <= dash_home_unique_activity_count * (1 + max_datastore_disparity)
+
+    def test_activity_count_consistency_iatistandard_homepage(self, registry_home_publisher_count, standard_home_activity_count):
+        """
+        Test to ensure the activity count is consistent, within a margin of error,
+        between the registry and the IATI Standard homepage.
+        """
+        max_registry_disparity = 0.03
+
+        assert registry_home_publisher_count >= standard_home_activity_count * (1 - max_registry_disparity)
+        assert registry_home_publisher_count <= standard_home_activity_count * (1 + max_registry_disparity)
 
     def test_activity_file_count_above_min(self, registry_activity_file_count, dash_home_activity_file_count, dash_files_activity_file_count):
         """
@@ -235,3 +256,13 @@ class TestGlobalConsistency(WebTestBase):
 
         assert registry_home_publisher_count >= query_builder_publisher_count * (1 - max_registry_disparity)
         assert registry_home_publisher_count <= query_builder_publisher_count * (1 + max_registry_disparity)
+
+    def test_publisher_count_consistency_iatistandard_homepage(self, registry_home_publisher_count, standard_home_publisher_count):
+        """
+        Test to ensure the publisher count is consistent, within a margin of error,
+        between the registry and the IATI Standard homepage.
+        """
+        max_registry_disparity = 0.03
+
+        assert registry_home_publisher_count >= standard_home_publisher_count * (1 - max_registry_disparity)
+        assert registry_home_publisher_count <= standard_home_publisher_count * (1 + max_registry_disparity)

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -112,11 +112,11 @@ class TestGlobalConsistency(WebTestBase):
 
     @pytest.fixture
     def standard_home_activity_count(cls):
-        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="num_iati_activities"]')
+        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="IATI-Website-Tests_num_iati_activities"]')
 
     @pytest.fixture
     def standard_home_publisher_count(cls):
-        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="num_iati_organisations"]')
+        return cls._locate_int_on_page('IATI Standard - Homepage', '//*[@id="IATI-Website-Tests_num_iati_organisations"]')
 
     def test_activity_count_above_min(self, dash_home_activity_count, dash_home_unique_activity_count, dash_activities_activity_count, dash_activities_unique_activity_count, datastore_api_activity_count):
         """

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -99,6 +99,10 @@ class TestGlobalConsistency(WebTestBase):
         return cls._locate_int_on_page('IATI Registry - Homepage', '//*[@id="home-icons"]/div/div[2]/div/a/strong')
 
     @pytest.fixture
+    def registry_activity_count(cls):
+        return utility.get_total_num_activities()
+
+    @pytest.fixture
     def registry_activity_file_count(cls):
         return cls._locate_int_on_page('IATI Registry - Activity Dataset Page', '//*[@id="content"]/div[3]/div/section[1]/div[1]/form/h2')
 
@@ -156,15 +160,15 @@ class TestGlobalConsistency(WebTestBase):
         assert datastore_api_activity_count >= dash_home_unique_activity_count * (1 - max_datastore_disparity)
         assert datastore_api_activity_count <= dash_home_unique_activity_count * (1 + max_datastore_disparity)
 
-    def test_activity_count_consistency_iatistandard_homepage(self, registry_home_publisher_count, standard_home_activity_count):
+    def test_activity_count_consistency_iatistandard_homepage(self, registry_activity_count, standard_home_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,
         between the registry and the IATI Standard homepage.
         """
         max_registry_disparity = 0.03
 
-        assert registry_home_publisher_count >= standard_home_activity_count * (1 - max_registry_disparity)
-        assert registry_home_publisher_count <= standard_home_activity_count * (1 + max_registry_disparity)
+        assert registry_activity_count >= standard_home_activity_count * (1 - max_registry_disparity)
+        assert registry_activity_count <= standard_home_activity_count * (1 + max_registry_disparity)
 
     def test_activity_file_count_above_min(self, registry_activity_file_count, dash_home_activity_file_count, dash_files_activity_file_count):
         """

--- a/tests/test_iati_standard.py
+++ b/tests/test_iati_standard.py
@@ -4,7 +4,6 @@ class TestIATIStandard(WebTestBase):
     """
     TODO: Add tests to assert that:
     - the number of activities and publishers roughly matches those displayed on the Registry
-    - a key string appears on the homepage
     """
     requests_to_load = {
         'IATI Standard Homepage - no www': {
@@ -31,6 +30,14 @@ class TestIATIStandard(WebTestBase):
         assert "/en/contact/" in result
         assert "/en/terms-and-conditions/" in result
         assert "/en/privacy-policy/" in result
+
+    def test_contains_expected_text(self, loaded_request):
+        """
+        Test that each homepage contains an expected substring.
+        """
+        text_to_find = "IATI is a global initiative to improve the transparency of development and humanitarian resources"
+
+        assert text_to_find in loaded_request.text
 
     def test_contains_newsletter_signup_form(self, loaded_request):
         """

--- a/tests/test_iati_standard.py
+++ b/tests/test_iati_standard.py
@@ -1,10 +1,6 @@
 from web_test_base import *
 
 class TestIATIStandard(WebTestBase):
-    """
-    TODO: Add tests to assert that:
-    - the number of activities and publishers roughly matches those displayed on the Registry
-    """
     requests_to_load = {
         'IATI Standard Homepage - no www': {
             'url': 'http://iatistandard.org'

--- a/tests/test_iati_standard.py
+++ b/tests/test_iati_standard.py
@@ -32,7 +32,7 @@ class TestIATIStandard(WebTestBase):
         assert "/en/terms-and-conditions/" in result
         assert "/en/privacy-policy/" in result
 
-    def test_newsletter_signup_form(self, loaded_request):
+    def test_contains_newsletter_signup_form(self, loaded_request):
         """
         Tests to confirm that there is always a form to subscribe to the newsletter within the footer.
         """

--- a/tests/test_iati_standard.py
+++ b/tests/test_iati_standard.py
@@ -4,7 +4,6 @@ class TestIATIStandard(WebTestBase):
     """
     TODO: Add tests to assert that:
     - the number of activities and publishers roughly matches those displayed on the Registry
-    - the newsletter form is present
     - a key string appears on the homepage
     """
     requests_to_load = {
@@ -33,4 +32,12 @@ class TestIATIStandard(WebTestBase):
         assert "/en/terms-and-conditions/" in result
         assert "/en/privacy-policy/" in result
 
+    def test_newsletter_signup_form(self, loaded_request):
+        """
+        Tests to confirm that there is always a form to subscribe to the newsletter within the footer.
+        """
+        xpath = '//*[@id="mc-embedded-subscribe-form"]'
 
+        result = utility.locate_xpath_result(loaded_request, xpath)
+
+        assert len(result) == 1

--- a/tests/utility/utility.py
+++ b/tests/utility/utility.py
@@ -1,5 +1,8 @@
+import json
 import os
 import re
+import requests
+
 from lxml import etree
 import pytest
 
@@ -94,3 +97,20 @@ def load_file_contents(file_name):
     with open(get_data_file(file_name), 'r') as myfile:
         data = myfile.read()
     return data
+
+ACTIVITY_URL = "https://iatiregistry.org/api/3/action/package_search?q=extras_filetype:activity&facet.field=[%22extras_activity_count%22]&start=0&rows=0&facet.limit=1000000"
+def get_total_num_activities():
+    """Query the IATI registry and return a faceted list of activity counts and their frequencies.
+
+    The total number of activities is then calculated as the sum of the product of a count and a frequency.
+    E.g. if "30" is the count and the frequency is 2, then the total number of activities is 60.
+    """
+    activity_request = requests.get(ACTIVITY_URL)
+    if activity_request.status_code == 200:
+        activity_json = json.loads(activity_request.content.decode('utf-8'))
+        activity_count = 0
+        for key in activity_json["result"]["facets"]["extras_activity_count"]:
+            activity_count += int(key) * activity_json["result"]["facets"]["extras_activity_count"][key]
+        return activity_count
+    else:
+        raise CommandError('Unable to connect to IATI registry to query activities.')


### PR DESCRIPTION
## Ensure https://github.com/IATI/preview-website/pull/200 is merged and deployed first!

Adds additional tests, removing a couple TODOs in the module docstring and therefore improving the robustness of the test for this sites.

Tests for e8b034d are expected to fail until https://github.com/IATI/preview-website/pull/200 is merged and deployed - suggest hitting `Restart build` in Travis when this is completed.

