### PR TITLE
Mark consistency check between the Dashboard and the Registry as xfail

### DIFF
--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -216,6 +216,7 @@ class TestGlobalConsistency(WebTestBase):
         """
         assert dash_home_publisher_count == dash_publishers_publisher_count
 
+    @pytest.mark.xfail(strict=True)
     def test_publisher_count_consistency_dashboard(self, registry_home_publisher_count, dash_home_publisher_count):
         """
         Test to ensure the publisher count is consistent, within a margin of error,


### PR DESCRIPTION
The Dashboard has not generated for some days, therefore the number of publishers reported is known to be out-of-date.