### PR TITLE
Add xfail to dashboard consistency test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==1.5.0 # rq.filter: <2.0
 lxml==3.8.0 # rq.filter: <4.0
-paramiko==2.4.1 # rq.filter: <3.0
+paramiko==2.4.2 # rq.filter: <3.0
 pytest==3.5.0 # rq.filter: <4.0
 python-dateutil==2.7.2 # rq.filter: <3.0
 pytz==2018.4

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -150,7 +150,7 @@ class TestGlobalConsistency(WebTestBase):
         assert dash_home_activity_count >= dash_home_unique_activity_count
         assert dash_activities_activity_count >= dash_activities_unique_activity_count
 
-    @pytest.mark.xfail
+    @pytest.mark.skip(reason="Data is often wrong due to delays between dashboard regeneration cycles")
     def test_activity_count_consistency_datastore_dashboard(self, datastore_api_activity_count, dash_home_unique_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,

--- a/tests/test_global_consistency.py
+++ b/tests/test_global_consistency.py
@@ -150,6 +150,7 @@ class TestGlobalConsistency(WebTestBase):
         assert dash_home_activity_count >= dash_home_unique_activity_count
         assert dash_activities_activity_count >= dash_activities_unique_activity_count
 
+    @pytest.mark.xfail
     def test_activity_count_consistency_datastore_dashboard(self, datastore_api_activity_count, dash_home_unique_activity_count):
         """
         Test to ensure the activity count is consistent, within a margin of error,


### PR DESCRIPTION
Adding an xfail to the dashboard consistency tests regarding the number of total activities, which constantly gives incorrect data due to the delays between dashboard regeneration cycles, this shall be reverted once a thorough investigation and cleanup of the tests is performed.  


