### PR TITLE
remove reference to aidtransparency website

### DIFF
--- a/tests/test_reference_documentation.py
+++ b/tests/test_reference_documentation.py
@@ -36,7 +36,6 @@ class TestIATIStandard(WebTestBase):
         """
         result = utility.get_links_from_page(loaded_request)
 
-        assert "http://www.aidtransparency.net/" in result
         assert "/" in result
         assert "http://iatiregistry.org" in result
         assert utility.regex_match_in_list('^(\.\./)*license/$', result)


### PR DESCRIPTION
Removing a lingering reference to aidtransparency website