### PR TITLE
Removed terms and conditions page from testing

### DIFF
--- a/tests/test_iati_standard.py
+++ b/tests/test_iati_standard.py
@@ -24,7 +24,6 @@ class TestIATIStandard(WebTestBase):
 
         # Selection of footer links
         assert "/en/contact/" in result
-        assert "/en/terms-and-conditions/" in result
         assert "/en/privacy-policy/" in result
 
     def test_contains_expected_text(self, loaded_request):


### PR DESCRIPTION
T&Cs for IATI Standard don't exist, there's been an empty page for these for a long time, it has now been removed. 