### PR TITLE
Fix dataset test (`dfid-af` 404s)

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -27,7 +27,7 @@ class TestIATIRegistry(WebTestBase):
             'url': 'https://iatiregistry.org/publisher/worldbank'
         },
         'IATI Registry: Random Dataset': {
-            'url': 'https://iatiregistry.org/dataset/dfid-af'
+            'url': 'https://iatiregistry.org/dataset/fcdo-af'
         },
         'IATI Registry API: Package Search Call': {
             'url': 'https://iatiregistry.org/api/3/action/package_search'


### PR DESCRIPTION
https://iatiregistry.org/dataset/dfid-af now 404s, causing this test to fail.

This PR replaces the requested dataset with this one:
https://iatiregistry.org/dataset/fcdo-af